### PR TITLE
Add options to mask seeds using the pin

### DIFF
--- a/src/main/java/uk/co/bitethebullet/android/token/HotpToken.java
+++ b/src/main/java/uk/co/bitethebullet/android/token/HotpToken.java
@@ -29,6 +29,8 @@ import java.util.TimeZone;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
+import uk.co.bitethebullet.android.token.util.Hex;
+
 
 /**
  * Hotp Token
@@ -106,6 +108,16 @@ public class HotpToken implements IToken {
 	}
 
 
+    public static String maskSeed(String seed, byte[] mask) {
+        return Hex.xorHexWith(seed, mask);
+    }
+
+
+    public void maskSeed(byte[] mask) {
+        this.mSeed = maskSeed(this.mSeed, mask);
+    }
+
+
 	protected long getEventCount() {
 		return mEventCount;
 	}
@@ -136,7 +148,7 @@ public class HotpToken implements IToken {
 			movingFactor >>= 8;
 		}
 		
-		byte[] hash = hmacSha(stringToHex(mSeed), counter);
+		byte[] hash = hmacSha(Hex.hexToByteArray(mSeed), counter);
 		int offset = hash[hash.length - 1] & 0xf;
 		
 		int otpBinary = ((hash[offset] & 0x7f) << 24)
@@ -153,17 +165,6 @@ public class HotpToken implements IToken {
 		}
 		
 		return result;		
-	}
-
-	public static byte[] stringToHex(String hexInputString){
-		
-		byte[] bts = new byte[hexInputString.length() / 2];
-		
-		for (int i = 0; i < bts.length; i++) {
-			bts[i] = (byte) Integer.parseInt(hexInputString.substring(2*i, 2*i+2), 16);
-		}
-		
-		return bts;
 	}
 
 	private byte[] hmacSha(byte[] seed, byte[] counter) {
@@ -220,29 +221,11 @@ public class HotpToken implements IToken {
 			
 			//convert to hex string			
 			
-			return byteArrayToHexString(digest);
+			return Hex.byteArrayToHex(digest);
 			
 		}catch(NoSuchAlgorithmException ex){
 			return null;		
 		}
-	}
-
-
-	public static String byteArrayToHexString(byte[] digest) {
-		
-		StringBuffer buffer = new StringBuffer();
-		
-		for(int i =0; i < digest.length; i++){
-			String hex = Integer.toHexString(0xff & digest[i]);
-			
-			if(hex.length() == 1)
-				buffer.append("0");
-			
-			buffer.append(hex);
-
-		}
-		
-		return buffer.toString();
 	}
 
 }

--- a/src/main/java/uk/co/bitethebullet/android/token/IToken.java
+++ b/src/main/java/uk/co/bitethebullet/android/token/IToken.java
@@ -34,4 +34,6 @@ public interface IToken {
 	public void setId(long id);
 	
 	public int getTimeStep();
+
+	public void maskSeed(byte[] mask);
 }

--- a/src/main/java/uk/co/bitethebullet/android/token/PinRemove.java
+++ b/src/main/java/uk/co/bitethebullet/android/token/PinRemove.java
@@ -49,15 +49,13 @@ public class PinRemove extends Activity {
 			
 			String pin = ((EditText)findViewById(R.id.pinRemoveExistingPinEdit)).getText().toString();
 			
-			if(PinManager.validatePin(v.getContext(), pin)){
-				PinManager.removePin(v.getContext());
-				finish();
-			}else{
+            if (!PinManager.removePin(v.getContext(), pin)) {
 				// the pin isn't the same as the one stored, do nothing
 				showDialog(DIALOG_INVALID_PIN);
 				return;
-			}
-			
+            }
+
+            finish();
 		}
 	};
 

--- a/src/main/java/uk/co/bitethebullet/android/token/TokenFactory.java
+++ b/src/main/java/uk/co/bitethebullet/android/token/TokenFactory.java
@@ -29,7 +29,7 @@ public class TokenFactory {
 	 * @param ctx
 	 * @return
 	 */
-	public static IToken CreateToken(Cursor c){
+	public static IToken CreateToken(Cursor c, byte[] seedMask){
 		
 		if(c == null){
 			return null;
@@ -53,7 +53,8 @@ public class TokenFactory {
 			return null;
 		}	
 		
-		token.setId(c.getLong(c.getColumnIndex(TokenDbAdapter.KEY_TOKEN_ROWID)));
+		token.setId(c.getLong(c.getColumnIndexOrThrow(TokenDbAdapter.KEY_TOKEN_ROWID)));
+        token.maskSeed(seedMask);
 		return token;
 	}
 	

--- a/src/main/java/uk/co/bitethebullet/android/token/util/Hex.java
+++ b/src/main/java/uk/co/bitethebullet/android/token/util/Hex.java
@@ -1,0 +1,50 @@
+package uk.co.bitethebullet.android.token.util;
+
+public class Hex {
+	private static final String HEX_ENCODING_TABLE = "0123456789abcdef";
+
+    private static void setHex(char[] hex, int i, byte b) {
+        hex[2*i] = HEX_ENCODING_TABLE.charAt((b & 0xf0) >> 4);
+        hex[2*i+1] = HEX_ENCODING_TABLE.charAt(b & 0x0f);
+    }
+
+    private static byte getHex(String hex, int i) {
+        return (byte)Integer.parseInt(hex.substring(2*i, 2*i+2), 16);
+    }
+    
+    public static String byteArrayToHex(byte[] bts) {
+        if (bts == null)
+            return null;
+
+        char[] hex = new char[bts.length * 2];
+
+        for (int i = 0; i < bts.length; i++)
+            setHex(hex, i, bts[i]);
+
+        return new String(hex);
+    }
+
+    public static byte[] hexToByteArray(String hex) {
+        if (hex == null)
+            return null;
+
+		byte[] bts = new byte[hex.length() / 2];
+		
+		for (int i = 0; i < bts.length; i++)
+			bts[i] = getHex(hex, i);
+		
+		return bts;
+    }
+
+    public static String xorHexWith(String hex, byte[] bts) {
+        if (bts == null || bts.length == 0)
+            return hex;
+
+        int bl = bts.length;
+        char[] out = new char[hex.length()];
+        for (int i = 0; i < out.length/2; i++)
+            setHex(out, i, (byte)(getHex(hex, i) ^ bts[i%bl]));
+
+        return new String(out);
+    }
+}

--- a/src/main/java/uk/co/bitethebullet/android/token/util/SeedConvertor.java
+++ b/src/main/java/uk/co/bitethebullet/android/token/util/SeedConvertor.java
@@ -20,7 +20,7 @@
 package uk.co.bitethebullet.android.token.util;
 
 import java.io.IOException;
-import uk.co.bitethebullet.android.token.HotpToken;
+import uk.co.bitethebullet.android.token.util.Hex;
 
 public class SeedConvertor {
 	
@@ -32,7 +32,7 @@ public class SeedConvertor {
 		
 		if(currentFormat == 0){
 			//hex
-			return HotpToken.stringToHex(input);
+			return Hex.hexToByteArray(input);
 		}else if(currentFormat == 1){
 			//base 32
 			Base32 base32 = new Base32();
@@ -47,7 +47,7 @@ public class SeedConvertor {
 	public static String ConvertFromBA(byte[] input, int targetFormat){
 		if(targetFormat == 0){
 			//hex
-			return HotpToken.byteArrayToHexString(input);
+			return Hex.byteArrayToHex(input);
 		}else if(targetFormat == 1){
 			//base 32
 			Base32 base32 = new Base32();

--- a/src/main/res/layout/pinchange.xml
+++ b/src/main/res/layout/pinchange.xml
@@ -41,6 +41,19 @@
     android:inputType="number"
     android:password="true" >
 </EditText>
+
+<CheckBox
+    android:id="@+id/pinChangeMaskSeed"
+    android:text="@string/pinChangeMaskSeed"
+    android:onClick="setNoValidateClickable"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"></CheckBox>
+<CheckBox
+    android:id="@+id/pinChangeNoValidate"
+    android:text="@string/pinChangeNoValidate"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"></CheckBox>
+
 <Button android:text="@string/pinChangeSubmit" 
 		android:id="@+id/pinChangeSubmit" 
 		android:layout_width="wrap_content" 

--- a/src/main/res/values/strings.xml
+++ b/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
 <string name="pinChangeExistingPin">Enter Existing PIN</string>
 <string name="pinChangeNew1">New PIN</string>
 <string name="pinChangeNew2">Confirm PIN</string>
+<string name="pinChangeMaskSeed">Use PIN to obscure seeds</string>
+<string name="pinChangeNoValidate">Allow incorrect PINs, producing incorrect tokens</string>
 <string name="pinChangeSubmit">Save</string>
 <string name="pinAlertInvalidPin">Existing PIN is invalid</string>
 <string name="pinAlertNewPinsDifferent">The new PINs are not the same</string>


### PR DESCRIPTION
Currently seeds are stored cleartext in the database. This option allows greater security, since the seeds are no longer trivially recoverable without the pin if it is set.  Also provides an even stronger security option to not validate the pin by not storing the hash at all.  Instead, incorrect pins just produce incorrect seeds and thus incorrect tokens, making it very difficult to recover the original seeds.  (Which of course has its downsides too, if you forget or mis-enter a PIN.  We could require the PIN to be entered twice in this case instead.)

Various refactoring of hex conversion and pin management used therein.